### PR TITLE
Add iOS PIP support

### DIFF
--- a/simple_live_app/ios/Runner/AppDelegate.swift
+++ b/simple_live_app/ios/Runner/AppDelegate.swift
@@ -3,11 +3,15 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
+  var iosPipPlugin: IosPipPlugin?
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    if let controller = window?.rootViewController as? FlutterViewController {
+      iosPipPlugin = IosPipPlugin(controller: controller)
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/simple_live_app/ios/Runner/IosPipPlugin.swift
+++ b/simple_live_app/ios/Runner/IosPipPlugin.swift
@@ -1,0 +1,72 @@
+import Foundation
+import AVKit
+import Flutter
+
+class IosPipPlugin: NSObject {
+  private var pipController: AVPictureInPictureController?
+  private let channel: FlutterMethodChannel
+  private weak var flutterController: FlutterViewController?
+
+  init(controller: FlutterViewController) {
+    self.flutterController = controller
+    self.channel = FlutterMethodChannel(name: "simple_live_ios_pip", binaryMessenger: controller.binaryMessenger)
+    super.init()
+    self.channel.setMethodCallHandler(handle)
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isAvailable":
+      if #available(iOS 14.0, *) {
+        result(AVPictureInPictureController.isPictureInPictureSupported())
+      } else {
+        result(false)
+      }
+    case "enable":
+      startPip(result: result)
+    case "disable":
+      stopPip(result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func startPip(result: @escaping FlutterResult) {
+    guard #available(iOS 14.0, *) else {
+      result(FlutterError(code: "unsupported", message: "iOS < 14", details: nil))
+      return
+    }
+    guard let controller = flutterController else {
+      result(FlutterError(code: "no_controller", message: "No FlutterViewController", details: nil))
+      return
+    }
+    // Search for AVPlayerLayer inside Flutter view hierarchy.
+    if let playerLayer = findPlayerLayer(in: controller.view.layer) {
+      pipController = AVPictureInPictureController(playerLayer: playerLayer)
+      pipController?.startPictureInPicture()
+      result(nil)
+    } else {
+      result(FlutterError(code: "no_player", message: "AVPlayerLayer not found", details: nil))
+    }
+  }
+
+  private func stopPip(result: @escaping FlutterResult) {
+    if #available(iOS 14.0, *) {
+      pipController?.stopPictureInPicture()
+    }
+    result(nil)
+  }
+
+  private func findPlayerLayer(in layer: CALayer) -> AVPlayerLayer? {
+    if let playerLayer = layer as? AVPlayerLayer {
+      return playerLayer
+    }
+    for sub in layer.sublayers ?? [] {
+      if let found = findPlayerLayer(in: sub) {
+        return found
+      }
+    }
+    return nil
+  }
+}
+

--- a/simple_live_app/lib/modules/live_room/player/player_controller.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controller.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:floating/floating.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:simple_live_app/pip/ios_pip.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:image_gallery_saver/image_gallery_saver.dart';
@@ -411,6 +412,15 @@ mixin PlayerSystemMixin on PlayerMixin, PlayerStateMixin, PlayerDanmakuMixin {
   bool danmakuStateBeforePIP = false;
 
   Future enablePIP() async {
+    if (Platform.isIOS) {
+      final iosPip = IosPip();
+      if (await iosPip.isPipAvailable() == false) {
+        SmartDialog.showToast("设备不支持小窗播放");
+        return;
+      }
+      await iosPip.enable();
+      return;
+    }
     if (!Platform.isAndroid) {
       return;
     }

--- a/simple_live_app/lib/pip/ios_pip.dart
+++ b/simple_live_app/lib/pip/ios_pip.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+
+/// Helper for interacting with iOS picture in picture.
+class IosPip {
+  static const MethodChannel _channel = MethodChannel('simple_live_ios_pip');
+
+  /// Whether PIP is supported on the current device.
+  Future<bool> isPipAvailable() async {
+    final available = await _channel.invokeMethod<bool>('isAvailable');
+    return available ?? false;
+  }
+
+  /// Enter picture in picture mode.
+  Future<void> enable() async {
+    await _channel.invokeMethod('enable');
+  }
+
+  /// Exit picture in picture mode.
+  Future<void> disable() async {
+    await _channel.invokeMethod('disable');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add simple iOS PIP helper via platform channel
- wire up plugin in iOS `AppDelegate`
- allow controller to trigger PIP on iOS

## Testing
- `flutter test` *(fails: `bash: flutter: command not found`)*