### PR TITLE
Add iOS PIP support

### DIFF
--- a/simple_live_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/simple_live_app/ios/Runner.xcodeproj/project.pbxproj
@@ -9,8 +9,9 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		73C9599770D417F3E7B681E2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60E92DDDD814CB6531C03BCD /* Pods_Runner.framework */; };
-		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+               73C9599770D417F3E7B681E2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60E92DDDD814CB6531C03BCD /* Pods_Runner.framework */; };
+               74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+               A0A0A0A0A0A0A0A0A0A0A0A2 /* IosPipPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A0A0A0A0A0A0A0A0A0A0A1 /* IosPipPlugin.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -38,7 +39,8 @@
 		60E92DDDD814CB6531C03BCD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C36D91D13E89663DBB13E51 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
-		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+               74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+               A0A0A0A0A0A0A0A0A0A0A0A1 /* IosPipPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IosPipPlugin.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -107,13 +109,14 @@
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
-				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
-				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
-				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
-			);
-			path = Runner;
-			sourceTree = "<group>";
-		};
+                               1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
+                               74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+                               74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+                               A0A0A0A0A0A0A0A0A0A0A0A1 /* IosPipPlugin.swift */,
+                       );
+                       path = Runner;
+                       sourceTree = "<group>";
+               };
 		FD158AC2F4211953A42B4A25 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -274,11 +277,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
-				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                               74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+                               A0A0A0A0A0A0A0A0A0A0A0A2 /* IosPipPlugin.swift in Sources */,
+                               1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
+                       );
+                       runOnlyForDeploymentPostprocessing = 0;
+               };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */

--- a/simple_live_app/ios/Runner/AppDelegate.swift
+++ b/simple_live_app/ios/Runner/AppDelegate.swift
@@ -3,11 +3,15 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
+  var iosPipPlugin: IosPipPlugin?
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    if let controller = window?.rootViewController as? FlutterViewController {
+      iosPipPlugin = IosPipPlugin(controller: controller)
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/simple_live_app/ios/Runner/IosPipPlugin.swift
+++ b/simple_live_app/ios/Runner/IosPipPlugin.swift
@@ -1,0 +1,72 @@
+import Foundation
+import AVKit
+import Flutter
+
+class IosPipPlugin: NSObject {
+  private var pipController: AVPictureInPictureController?
+  private let channel: FlutterMethodChannel
+  private weak var flutterController: FlutterViewController?
+
+  init(controller: FlutterViewController) {
+    self.flutterController = controller
+    self.channel = FlutterMethodChannel(name: "simple_live_ios_pip", binaryMessenger: controller.binaryMessenger)
+    super.init()
+    self.channel.setMethodCallHandler(handle)
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isAvailable":
+      if #available(iOS 14.0, *) {
+        result(AVPictureInPictureController.isPictureInPictureSupported())
+      } else {
+        result(false)
+      }
+    case "enable":
+      startPip(result: result)
+    case "disable":
+      stopPip(result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func startPip(result: @escaping FlutterResult) {
+    guard #available(iOS 14.0, *) else {
+      result(FlutterError(code: "unsupported", message: "iOS < 14", details: nil))
+      return
+    }
+    guard let controller = flutterController else {
+      result(FlutterError(code: "no_controller", message: "No FlutterViewController", details: nil))
+      return
+    }
+    // Search for AVPlayerLayer inside Flutter view hierarchy.
+    if let playerLayer = findPlayerLayer(in: controller.view.layer) {
+      pipController = AVPictureInPictureController(playerLayer: playerLayer)
+      pipController?.startPictureInPicture()
+      result(nil)
+    } else {
+      result(FlutterError(code: "no_player", message: "AVPlayerLayer not found", details: nil))
+    }
+  }
+
+  private func stopPip(result: @escaping FlutterResult) {
+    if #available(iOS 14.0, *) {
+      pipController?.stopPictureInPicture()
+    }
+    result(nil)
+  }
+
+  private func findPlayerLayer(in layer: CALayer) -> AVPlayerLayer? {
+    if let playerLayer = layer as? AVPlayerLayer {
+      return playerLayer
+    }
+    for sub in layer.sublayers ?? [] {
+      if let found = findPlayerLayer(in: sub) {
+        return found
+      }
+    }
+    return nil
+  }
+}
+

--- a/simple_live_app/lib/modules/live_room/player/player_controller.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controller.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:floating/floating.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:simple_live_app/pip/ios_pip.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:image_gallery_saver/image_gallery_saver.dart';
@@ -411,6 +412,15 @@ mixin PlayerSystemMixin on PlayerMixin, PlayerStateMixin, PlayerDanmakuMixin {
   bool danmakuStateBeforePIP = false;
 
   Future enablePIP() async {
+    if (Platform.isIOS) {
+      final iosPip = IosPip();
+      if (await iosPip.isPipAvailable() == false) {
+        SmartDialog.showToast("设备不支持小窗播放");
+        return;
+      }
+      await iosPip.enable();
+      return;
+    }
     if (!Platform.isAndroid) {
       return;
     }

--- a/simple_live_app/lib/pip/ios_pip.dart
+++ b/simple_live_app/lib/pip/ios_pip.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+
+/// Helper for interacting with iOS picture in picture.
+class IosPip {
+  static const MethodChannel _channel = MethodChannel('simple_live_ios_pip');
+
+  /// Whether PIP is supported on the current device.
+  Future<bool> isPipAvailable() async {
+    final available = await _channel.invokeMethod<bool>('isAvailable');
+    return available ?? false;
+  }
+
+  /// Enter picture in picture mode.
+  Future<void> enable() async {
+    await _channel.invokeMethod('enable');
+  }
+
+  /// Exit picture in picture mode.
+  Future<void> disable() async {
+    await _channel.invokeMethod('disable');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add simple iOS PIP helper via platform channel
- wire up plugin in iOS `AppDelegate`
- allow controller to trigger PIP on iOS
- add plugin file to Xcode project to fix build error

## Testing
- `flutter test` *(fails: `bash: flutter: command not found`)*
